### PR TITLE
feat: add general report parser for club data

### DIFF
--- a/era_data_merger.py
+++ b/era_data_merger.py
@@ -1,310 +1,451 @@
 import streamlit as st
 import pandas as pd
 import io
+import warnings
 from datetime import datetime
 from parts_data import PARTS_DATA_RAW
 
-st.set_page_config(page_title="ERA Data Merger", layout="centered")
-st.title("🔄 ERA Club & Production Data Merger")
+# Constants for general report parsing
+OLD_PRICE_COLUMNS = [
+    "Sell Price (DT)",
+    "Sell Price (FT)",
+    "Sell Price (STK)",
+    "Sell Price (STA)",
+    "Sell Price (RFP)",
+]
 
-# --- PARTS LOOKUP TRANSFORM ---
-PARTS_DATA = {}
-for part_data in PARTS_DATA_RAW.values():
-    PARTS_DATA[part_data["Part Name"]] = {
-        "Size": f"{part_data['Height (mm)']}x{part_data['Width (mm)']}",
-        "Pagination": part_data["No. of Pages"],
-        "Material": part_data["Materials"],
-        "Finishing": part_data.get("Finishing", "")
-    }
+BASE_COLUMNS = [
+    "Order Owner",
+    "Order Status",
+    "Local Marketing Order Ref",
+    "Stock Order Ref",
+    "Order Placed Date",
+    "Order Line Reference",
+    "Local Marketing Asset",
+    "Local Marketing Order Line Ref",
+    "Stock Item",
+    "Stock Order Line Ref",
+    "Part",
+    "Quantity",
+    "Date Approved",
+    "Location",
+    "Workflow Reference Number",
+]
 
-# --- SESSION STATE SETUP ---
-if "step" not in st.session_state:
-    st.session_state.step = 1
+COST_COLUMNS = [
+    "If tender pre 5.25%",
+    "Print",
+    "Collate & pack",
+    "Despatch",
+    "Total",
+]
 
-if "club_files" not in st.session_state:
-    st.session_state.club_files = []
+FINAL_COLUMNS = BASE_COLUMNS + COST_COLUMNS
 
-if "prod_files" not in st.session_state:
-    st.session_state.prod_files = []
 
-# --- STEP 1: CLUB ORDERS ---
-st.header("Step 1: Upload Club Orders")
-st.caption("Upload one or more club order files")
-club_files = st.file_uploader("Choose Club Orders Excel file(s)", type="xlsx", accept_multiple_files=True)
+def parse_general_report(df: pd.DataFrame) -> pd.DataFrame:
+    """Parse a general_report sheet into a unified schema."""
 
-if club_files:
-    st.session_state.club_files = club_files
-    st.success("Club Orders uploaded. Proceed to Step 2")
-    st.session_state.step = 2
+    # --- Promote header row ---
+    header_row_idx = None
+    for i in range(len(df)):
+        if df.iloc[i].notna().any():
+            header_row_idx = i
+            break
+    if header_row_idx is None:
+        raise ValueError("Could not determine header row")
 
-# --- STEP 2: PRODUCTION DATA ---
-if st.session_state.step >= 2:
-    st.header("Step 2: Upload Production Data")
-    st.caption("Upload BOTH the Print and C&P files")
-    prod_files = st.file_uploader("Choose Production Excel files (2 required)", type="xlsx", accept_multiple_files=True)
+    header = df.iloc[header_row_idx].astype(str).str.strip()
+    df = df.iloc[header_row_idx + 1 :].reset_index(drop=True)
+    df.columns = header
+    df.columns = df.columns.astype(str).str.strip()
+    df = df.dropna(how="all")
 
-    if prod_files and len(prod_files) == 2:
-        st.session_state.prod_files = prod_files
-        st.success("Production files uploaded. Proceed to generate output")
-        st.session_state.step = 3
-    elif prod_files and len(prod_files) != 2:
-        st.error("Please upload exactly 2 production files: 1 Print and 1 C&P file")
+    # --- Detect format ---
+    is_old = any(col in df.columns for col in OLD_PRICE_COLUMNS)
+    is_new = ("Total" in df.columns) and any(
+        col in df.columns for col in ["Print", "Collate & pack", "Despatch"]
+    )
+    if not (is_old or is_new):
+        raise ValueError(
+            "Unrecognized general_report format. Expected Sell Price columns or Total with Print/Collate & pack/Despatch columns."
+        )
 
-# --- STEP 3: PROCESS & DOWNLOAD ---
-if st.session_state.step == 3:
-    if st.button("Generate Combined Output"):
-        with st.spinner("Processing your files..."):
-            try:
-                today = datetime.today().strftime("%Y-%m-%d")
+    # --- Validate required columns ---
+    missing = [c for c in BASE_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
 
-                # --- Load club files ---
-                club_dfs = []
-                for f in st.session_state.club_files:
-                    df = pd.read_excel(f, header=1)
-                    # Calculate total sell price from all price columns
-                    price_columns = [
-                        'Sell Price (DT)',
-                        'Sell Price (FT)',
-                        'Sell Price (STK)',
-                        'Sell Price (STA)',
-                        'Sell Price (RFP)'
-                    ]
-                    df['Total_Print_Sell'] = df[price_columns].sum(axis=1, skipna=True)
-                    club_dfs.append(df)
-                
-                club_df = pd.concat(club_dfs, ignore_index=True)
-                club_df.columns = club_df.columns.str.strip()
+    df = df.copy()
 
-                # --- Load production files ---
-                df1 = pd.read_excel(st.session_state.prod_files[0], header=1)
-                df2 = pd.read_excel(st.session_state.prod_files[1], header=1)
-                df1.columns = df1.columns.str.strip()
-                df2.columns = df2.columns.str.strip()
+    # --- Map to unified schema ---
+    if is_old:
+        # Create cost columns with zeros
+        for col in ["If tender pre 5.25%", "Print", "Collate & pack", "Despatch"]:
+            df[col] = 0
+        df["Total"] = (
+            df[OLD_PRICE_COLUMNS].apply(pd.to_numeric, errors="coerce").sum(axis=1, skipna=True)
+        )
+    else:
+        # Ensure all cost columns exist
+        for col in COST_COLUMNS:
+            if col not in df.columns:
+                df[col] = 0
 
-                df_cp = df1 if "Collate And Pack Cost Price" in df1.columns else df2
-                df_print = df2 if df_cp is df1 else df1
+    # --- Type coercion ---
+    for col in COST_COLUMNS:
+        df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0.0)
 
-                cp_lookup = df_cp.set_index("Project Ref")["Collate And Pack Cost Price"].to_dict()
+    df["Order Placed Date"] = pd.to_datetime(
+        df["Order Placed Date"], dayfirst=True, errors="coerce"
+    )
+    df["Date Approved"] = pd.to_datetime(
+        df["Date Approved"], dayfirst=True, errors="coerce"
+    )
 
-                # --- Transform Club Orders ---
-                club_rows = []
-                index_counter = 1
+    quantity_num = pd.to_numeric(df["Quantity"], errors="coerce")
+    if quantity_num.isna().any():
+        warnings.warn("Non-numeric Quantity values coerced to 0")
+    df["Quantity"] = quantity_num.fillna(0).astype(int)
 
-                for _, row in club_df.iterrows():
-                    part = row.get("Part")
-                    part_info = PARTS_DATA.get(part, {})
+    if (df["Total"] < 0).any():
+        warnings.warn("Negative Total values found")
 
-                    try:
-                        p_val = float(row.get("Total_Print_Sell", 0))
-                        cp_val = 2.35
-                        d_val = 5.33
-                    except:
-                        p_val, cp_val, d_val = 0, 2.35, 5.33
+    df = df[FINAL_COLUMNS]
+    return df
 
-                    # Row 1
-                    club_rows.append({
-                        "index no": index_counter,
-                        "Matrix": "",
-                        "Matrix URN": "",
-                        "Order type": "Club",
-                        "Project Ref": row.get("Local Marketing Order Ref", ""),
-                        "Project name": "Club",
-                        "Brief ref": row.get("Local Marketing Order Line Ref", ""),
-                        "Product": part,
-                        "Size": part_info.get("Size", ""),
-                        "Pagination": part_info.get("Pagination", ""),
-                        "Material": part_info.get("Material", ""),
-                        "Finishing": part_info.get("Finishing", ""),
-                        "Quantity": row.get("Quantity", ""),
-                        "Print Matrix": "",
-                        "Print Sell": p_val,
-                        "Sell": "",
-                        "Number of clubs": 1,
-                        "Comment": "",
-                        "ERA Comments": "",
-                        "ITG Comment": "",
-                        "Credit": ""
-                    })
 
-                    # Row 2: C&P
-                    club_rows.append({
-                        "index no": index_counter,
-                        "Matrix": "",
-                        "Matrix URN": "",
-                        "Order type": "Club",
-                        "Project Ref": row.get("Local Marketing Order Ref", ""),
-                        "Project name": "Club",
-                        "Brief ref": row.get("Local Marketing Order Line Ref", ""),
-                        "Product": "C&P",
-                        "Size": "",
-                        "Pagination": "",
-                        "Material": "",
-                        "Finishing": "C&P",
-                        "Quantity": 1,
-                        "Print Matrix": "",
-                        "Print Sell": cp_val,
-                        "Sell": "",
-                        "Number of clubs": 1,
-                        "Comment": "",
-                        "ERA Comments": "",
-                        "ITG Comment": "",
-                        "Credit": ""
-                    })
+def main():
+    st.set_page_config(page_title="ERA Data Merger", layout="centered")
+    st.title("🔄 ERA Club & Production Data Merger")
 
-                    # Row 3: Delivery
-                    club_rows.append({
-                        "index no": index_counter,
-                        "Matrix": "",
-                        "Matrix URN": "",
-                        "Order type": "Club",
-                        "Project Ref": row.get("Local Marketing Order Ref", ""),
-                        "Project name": "Club",
-                        "Brief ref": row.get("Local Marketing Order Line Ref", ""),
-                        "Product": "Delivery",
-                        "Size": "",
-                        "Pagination": "",
-                        "Material": "",
-                        "Finishing": "Delivery",
-                        "Quantity": 1,
-                        "Print Matrix": "",
-                        "Print Sell": d_val,
-                        "Sell": p_val + cp_val + d_val,
-                        "Number of clubs": 1,
-                        "Comment": "",
-                        "ERA Comments": "",
-                        "ITG Comment": "",
-                        "Credit": ""
-                    })
+    # --- PARTS LOOKUP TRANSFORM ---
+    PARTS_DATA = {}
+    for part_data in PARTS_DATA_RAW.values():
+        PARTS_DATA[part_data["Part Name"]] = {
+            "Size": f"{part_data['Height (mm)']}x{part_data['Width (mm)']}",
+            "Pagination": part_data["No. of Pages"],
+            "Material": part_data["Materials"],
+            "Finishing": part_data.get("Finishing", ""),
+        }
 
-                    index_counter += 1
+    # --- SESSION STATE SETUP ---
+    if "step" not in st.session_state:
+        st.session_state.step = 1
 
-                df_club_out = pd.DataFrame(club_rows)
+    if "club_files" not in st.session_state:
+        st.session_state.club_files = []
 
-                # --- Transform Production Data ---
-                grouped = df_print.groupby("Project Ref")
-                prod_rows = []
+    if "prod_files" not in st.session_state:
+        st.session_state.prod_files = []
 
-                for project_ref, group in grouped:
-                    current_index = index_counter
-                    project_name = group["Project Description"].iloc[0]
-                    cp_cost = cp_lookup.get(project_ref, "NOT FOUND")
-                    total_sell = 0
+    # --- STEP 1: CLUB ORDERS ---
+    st.header("Step 1: Upload Club Orders")
+    st.caption("Upload one or more club order files")
+    club_files = st.file_uploader(
+        "Choose Club Orders Excel file(s)", type="xlsx", accept_multiple_files=True
+    )
 
-                    for _, row in group.iterrows():
-                        try:
-                            sell = float(row.get("Production Sell Price", 0))
-                        except:
-                            sell = 0
-                        total_sell += sell
+    if club_files:
+        st.session_state.club_files = club_files
+        st.success("Club Orders uploaded. Proceed to Step 2")
+        st.session_state.step = 2
 
-                        prod_rows.append({
-                            "index no": current_index,
-                            "Matrix": "Matrix",
-                            "Matrix URN": "",
-                            "Order type": "Camp / Misc",
-                            "Project Ref": row.get("Project Ref", ""),
-                            "Project name": row.get("Project Description", ""),
-                            "Brief ref": row.get("Brief Ref", ""),
-                            "Product": row.get("Part", ""),
-                            "Size": f"{row.get('Height', '')}x{row.get('Width', '')}",
-                            "Pagination": row.get("No of Pages", ""),
-                            "Material": row.get("Material", ""),
-                            "Finishing": row.get("Production Finishing Notes", ""),
-                            "Quantity": row.get("Total including Spares", ""),
-                            "Print Matrix": "",
-                            "Print Sell": sell,
-                            "Sell": "",
-                            "Number of clubs": row.get("No of Clubs", ""),
-                            "Comment": "",
-                            "ERA Comments": "",
-                            "ITG Comment": "",
-                            "Credit": ""
-                        })
+    # --- STEP 2: PRODUCTION DATA ---
+    if st.session_state.step >= 2:
+        st.header("Step 2: Upload Production Data")
+        st.caption("Upload BOTH the Print and C&P files")
+        prod_files = st.file_uploader(
+            "Choose Production Excel files (2 required)",
+            type="xlsx",
+            accept_multiple_files=True,
+        )
 
-                    prod_rows.append({
-                        "index no": current_index,
-                        "Matrix": "Matrix",
-                        "Matrix URN": "",
-                        "Order type": "Camp / Misc",
-                        "Project Ref": project_ref,
-                        "Project name": project_name,
-                        "Brief ref": "",
-                        "Product": "C&P",
-                        "Size": "",
-                        "Pagination": "",
-                        "Material": "",
-                        "Finishing": "C&P",
-                        "Quantity": "",
-                        "Print Matrix": "",
-                        "Print Sell": cp_cost,
-                        "Sell": total_sell + (cp_cost if isinstance(cp_cost, (int, float)) else 0),
-                        "Number of clubs": group["No of Clubs"].iloc[0],
-                        "Comment": "",
-                        "ERA Comments": "",
-                        "ITG Comment": "",
-                        "Credit": ""
-                    })
+        if prod_files and len(prod_files) == 2:
+            st.session_state.prod_files = prod_files
+            st.success("Production files uploaded. Proceed to generate output")
+            st.session_state.step = 3
+        elif prod_files and len(prod_files) != 2:
+            st.error("Please upload exactly 2 production files: 1 Print and 1 C&P file")
 
-                    index_counter += 1
+    # --- STEP 3: PROCESS & DOWNLOAD ---
+    if st.session_state.step == 3:
+        if st.button("Generate Combined Output"):
+            with st.spinner("Processing your files..."):
+                try:
+                    today = datetime.today().strftime("%Y-%m-%d")
 
-                df_prod_out = pd.DataFrame(prod_rows)
+                    # --- Load club files ---
+                    club_dfs = []
+                    for f in st.session_state.club_files:
+                        raw_df = pd.read_excel(f, header=None)
+                        df = parse_general_report(raw_df)
+                        club_dfs.append(df)
 
-                # --- Combine outputs ---
-                final_df = pd.concat([df_club_out, df_prod_out], ignore_index=True)
+                    club_df = pd.concat(club_dfs, ignore_index=True)
 
-                # Save to buffer
-                buffer = io.BytesIO()
-                with pd.ExcelWriter(buffer, engine='xlsxwriter') as writer:
-                    final_df.to_excel(writer, sheet_name='Combined Data', index=False)
-                    
-                    # Get the xlsxwriter workbook and worksheet objects
-                    workbook = writer.book
-                    worksheet = writer.sheets['Combined Data']
-                    
-                    # Define formats
-                    border_fmt = workbook.add_format({
-                        'border': 1,  # Thin border
-                        'border_color': '#000000'  # Black color
-                    })
-                    
-                    header_fmt = workbook.add_format({
-                        'border': 1,
-                        'border_color': '#000000',
-                        'bold': True,
-                        'text_wrap': True,
-                        'valign': 'top'
-                    })
-                    
-                    # Apply formats to the header row
-                    for col_num, value in enumerate(final_df.columns.values):
-                        worksheet.write(0, col_num, value, header_fmt)
-                    
-                    # Auto-fit column widths based on data
-                    for idx, col in enumerate(final_df.columns):
-                        series = final_df[col]
-                        max_len = max(
-                            series.astype(str).apply(len).max(),  # max length of values
-                            len(str(series.name))  # length of column name
-                        ) + 2  # adding a little extra space
-                        worksheet.set_column(idx, idx, max_len)
-                    
-                    # Apply borders to the data range
-                    worksheet.conditional_format(
-                        0, 0, len(final_df), len(final_df.columns)-1,
-                        {'type': 'no_blanks', 'format': border_fmt}
+                    # --- Load production files ---
+                    df1 = pd.read_excel(st.session_state.prod_files[0], header=1)
+                    df2 = pd.read_excel(st.session_state.prod_files[1], header=1)
+                    df1.columns = df1.columns.str.strip()
+                    df2.columns = df2.columns.str.strip()
+
+                    df_cp = df1 if "Collate And Pack Cost Price" in df1.columns else df2
+                    df_print = df2 if df_cp is df1 else df1
+
+                    cp_lookup = df_cp.set_index("Project Ref")[
+                        "Collate And Pack Cost Price"
+                    ].to_dict()
+
+                    # --- Transform Club Orders ---
+                    club_rows = []
+                    index_counter = 1
+
+                    for _, row in club_df.iterrows():
+                        part = row.get("Part")
+                        part_info = PARTS_DATA.get(part, {})
+
+                        print_val = row.get("Print", 0)
+                        if pd.isna(print_val) or print_val == 0:
+                            print_val = row.get("Total", 0)
+
+                        cp_val = row.get("Collate & pack", 0)
+                        if pd.isna(cp_val) or cp_val == 0:
+                            cp_val = 2.35
+
+                        d_val = row.get("Despatch", 0)
+                        if pd.isna(d_val) or d_val == 0:
+                            d_val = 5.33
+
+                        sell_total = row.get("Total", 0)
+                        if pd.isna(sell_total) or sell_total == 0:
+                            sell_total = print_val + cp_val + d_val
+
+                        # Row 1
+                        club_rows.append(
+                            {
+                                "index no": index_counter,
+                                "Matrix": "",
+                                "Matrix URN": "",
+                                "Order type": "Club",
+                                "Project Ref": row.get("Local Marketing Order Ref", ""),
+                                "Project name": "Club",
+                                "Brief ref": row.get("Local Marketing Order Line Ref", ""),
+                                "Product": part,
+                                "Size": part_info.get("Size", ""),
+                                "Pagination": part_info.get("Pagination", ""),
+                                "Material": part_info.get("Material", ""),
+                                "Finishing": part_info.get("Finishing", ""),
+                                "Quantity": row.get("Quantity", ""),
+                                "Print Matrix": "",
+                                "Print Sell": print_val,
+                                "Sell": "",
+                                "Number of clubs": 1,
+                                "Comment": "",
+                                "ERA Comments": "",
+                                "ITG Comment": "",
+                                "Credit": "",
+                            }
+                        )
+
+                        # Row 2: C&P
+                        club_rows.append(
+                            {
+                                "index no": index_counter,
+                                "Matrix": "",
+                                "Matrix URN": "",
+                                "Order type": "Club",
+                                "Project Ref": row.get("Local Marketing Order Ref", ""),
+                                "Project name": "Club",
+                                "Brief ref": row.get("Local Marketing Order Line Ref", ""),
+                                "Product": "C&P",
+                                "Size": "",
+                                "Pagination": "",
+                                "Material": "",
+                                "Finishing": "C&P",
+                                "Quantity": 1,
+                                "Print Matrix": "",
+                                "Print Sell": cp_val,
+                                "Sell": "",
+                                "Number of clubs": 1,
+                                "Comment": "",
+                                "ERA Comments": "",
+                                "ITG Comment": "",
+                                "Credit": "",
+                            }
+                        )
+
+                        # Row 3: Delivery
+                        club_rows.append(
+                            {
+                                "index no": index_counter,
+                                "Matrix": "",
+                                "Matrix URN": "",
+                                "Order type": "Club",
+                                "Project Ref": row.get("Local Marketing Order Ref", ""),
+                                "Project name": "Club",
+                                "Brief ref": row.get("Local Marketing Order Line Ref", ""),
+                                "Product": "Delivery",
+                                "Size": "",
+                                "Pagination": "",
+                                "Material": "",
+                                "Finishing": "Delivery",
+                                "Quantity": 1,
+                                "Print Matrix": "",
+                                "Print Sell": d_val,
+                                "Sell": sell_total,
+                                "Number of clubs": 1,
+                                "Comment": "",
+                                "ERA Comments": "",
+                                "ITG Comment": "",
+                                "Credit": "",
+                            }
+                        )
+
+                        index_counter += 1
+
+                    df_club_out = pd.DataFrame(club_rows)
+
+                    # --- Transform Production Data ---
+                    grouped = df_print.groupby("Project Ref")
+                    prod_rows = []
+
+                    for project_ref, group in grouped:
+                        current_index = index_counter
+                        project_name = group["Project Description"].iloc[0]
+                        cp_cost = cp_lookup.get(project_ref, "NOT FOUND")
+                        total_sell = 0
+
+                        for _, row in group.iterrows():
+                            try:
+                                sell = float(row.get("Production Sell Price", 0))
+                            except Exception:
+                                sell = 0
+                            total_sell += sell
+
+                            prod_rows.append(
+                                {
+                                    "index no": current_index,
+                                    "Matrix": "Matrix",
+                                    "Matrix URN": "",
+                                    "Order type": "Camp / Misc",
+                                    "Project Ref": row.get("Project Ref", ""),
+                                    "Project name": row.get("Project Description", ""),
+                                    "Brief ref": row.get("Brief Ref", ""),
+                                    "Product": row.get("Part", ""),
+                                    "Size": f"{row.get('Height', '')}x{row.get('Width', '')}",
+                                    "Pagination": row.get("No of Pages", ""),
+                                    "Material": row.get("Material", ""),
+                                    "Finishing": row.get("Production Finishing Notes", ""),
+                                    "Quantity": row.get("Total including Spares", ""),
+                                    "Print Matrix": "",
+                                    "Print Sell": sell,
+                                    "Sell": "",
+                                    "Number of clubs": row.get("No of Clubs", ""),
+                                    "Comment": "",
+                                    "ERA Comments": "",
+                                    "ITG Comment": "",
+                                    "Credit": "",
+                                }
+                            )
+
+                        prod_rows.append(
+                            {
+                                "index no": current_index,
+                                "Matrix": "Matrix",
+                                "Matrix URN": "",
+                                "Order type": "Camp / Misc",
+                                "Project Ref": project_ref,
+                                "Project name": project_name,
+                                "Brief ref": "",
+                                "Product": "C&P",
+                                "Size": "",
+                                "Pagination": "",
+                                "Material": "",
+                                "Finishing": "C&P",
+                                "Quantity": "",
+                                "Print Matrix": "",
+                                "Print Sell": cp_cost,
+                                "Sell": total_sell
+                                + (cp_cost if isinstance(cp_cost, (int, float)) else 0),
+                                "Number of clubs": group["No of Clubs"].iloc[0],
+                                "Comment": "",
+                                "ERA Comments": "",
+                                "ITG Comment": "",
+                                "Credit": "",
+                            }
+                        )
+
+                        index_counter += 1
+
+                    df_prod_out = pd.DataFrame(prod_rows)
+
+                    # --- Combine outputs ---
+                    final_df = pd.concat([df_club_out, df_prod_out], ignore_index=True)
+
+                    # Save to buffer
+                    buffer = io.BytesIO()
+                    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+                        final_df.to_excel(writer, sheet_name="Combined Data", index=False)
+
+                        workbook = writer.book
+                        worksheet = writer.sheets["Combined Data"]
+
+                        border_fmt = workbook.add_format(
+                            {
+                                "border": 1,
+                                "border_color": "#000000",
+                            }
+                        )
+
+                        header_fmt = workbook.add_format(
+                            {
+                                "border": 1,
+                                "border_color": "#000000",
+                                "bold": True,
+                                "text_wrap": True,
+                                "valign": "top",
+                            }
+                        )
+
+                        for col_num, value in enumerate(final_df.columns.values):
+                            worksheet.write(0, col_num, value, header_fmt)
+
+                        for idx, col in enumerate(final_df.columns):
+                            series = final_df[col]
+                            max_len = max(
+                                series.astype(str).apply(len).max(),
+                                len(str(series.name)),
+                            ) + 2
+                            worksheet.set_column(idx, idx, max_len)
+
+                        worksheet.conditional_format(
+                            0,
+                            0,
+                            len(final_df),
+                            len(final_df.columns) - 1,
+                            {"type": "no_blanks", "format": border_fmt},
+                        )
+                        worksheet.conditional_format(
+                            0,
+                            0,
+                            len(final_df),
+                            len(final_df.columns) - 1,
+                            {"type": "blanks", "format": border_fmt},
+                        )
+
+                    buffer.seek(0)
+                    st.download_button(
+                        label="Download Combined Data",
+                        data=buffer,
+                        file_name=f"ERA_Combined_Data_{today}.xlsx",
+                        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                     )
-                    worksheet.conditional_format(
-                        0, 0, len(final_df), len(final_df.columns)-1,
-                        {'type': 'blanks', 'format': border_fmt}
-                    )
-                
-                buffer.seek(0)
-                st.download_button(
-                    label="Download Combined Data",
-                    data=buffer,
-                    file_name=f"ERA_Combined_Data_{today}.xlsx",
-                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                )
-                st.success("Data processing complete! Click the button above to download.")
-            except Exception as e:
-                st.error(f"An error occurred: {str(e)}")
+                    st.success("Data processing complete! Click the button above to download.")
+                except Exception as e:
+                    st.error(f"An error occurred: {str(e)}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_parse_general_report.py
+++ b/tests/test_parse_general_report.py
@@ -1,0 +1,44 @@
+import io
+import os
+import sys
+import pandas as pd
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from era_data_merger import parse_general_report, FINAL_COLUMNS
+
+OLD_CSV = """Order Owner,Order Status,Local Marketing Order Ref,Stock Order Ref,Order Placed Date,Order Line Reference,Local Marketing Asset,Local Marketing Order Line Ref,Stock Item,Stock Order Line Ref,Part,Quantity,Date Approved,Location,Workflow Reference Number,Sell Price (DT),Sell Price (FT),Sell Price (STK),Sell Price (STA),Sell Price (RFP),Buy Price (DT),Buy Price (FT)
+5467 Blackburn,In Progress,BZL13333,,2025-07-08 17:28:28,24543/2,AS89292,BZL13333/43034,,,40x30 Poster OT,2,2025-07-11 16:21:38,Blackburn,BUZ17550/125557,0,9.82,0,0,0,0,13.1
+5611 Barnsley Pontefract Road,In Progress,BZL13313,,2025-06-30 20:06:11,24610/6,AS87957,BZL13313/42982,,,A7 2pp Voucher (L) OT,100,2025-07-07 13:12:49,Barnsley Pontefract Road,BUZ17503/125411,0,17.18,0,0,0,0,2
+5611 Barnsley Pontefract Road,In Progress,BZL13313,,2025-06-30 20:06:11,24610/7,AS86292,BZL13313/42981,,,A5 2PP Leaflet OT,200,2025-07-07 13:12:49,Barnsley Pontefract Road,BUZ17503/125410,0,4.89,0,0,0,0,40
+5878 Sheffield Wadsley,In Progress,BZL13314,,2025-07-01 13:39:53,24614/7,AS85197,BZL13314/42987,,,40x30 Poster OT,4,2025-07-07 13:20:31,Sheffield Wadsley,BUZ17504/125416,19.64,0,0,0,0,26.19,0
+5823 Washington,In Progress,BZL13315,,2025-07-01 14:41:11,24615/2,AS85987,BZL13315/42997,,,60x40 Poster OT,2,2025-07-07 13:23:02,Washington,BUZ17505/125426,17.14,0,0,0,0,21.38,0
+"""
+
+NEW_CSV = """Order Owner,Order Status,Local Marketing Order Ref,Stock Order Ref,Order Placed Date,Order Line Reference,Local Marketing Asset,Local Marketing Order Line Ref,Stock Item,Stock Order Line Ref,Part,Quantity,Date Approved,Location,Workflow Reference Number,If tender pre 5.25%,Print,Collate & pack,Despatch,Total
+5861 Poole,Part Delivered,BZL13289,B3260,2025-06-27 14:44:50,24594/3,,,BUZ15866/118699,B3260/3,A5 2pp Perforated leaflet,2,2025-06-30 14:11:57,Poole,,,0,4.7,9.3,14
+5861 Poole,Part Delivered,BZL13289,B3260,2025-06-27 14:44:50,24594/5,AS87957,BZL13289/42898,,,A7 2pp Voucher (L) OT,350,2025-06-30 14:11:57,Poole,BUZ17445/125121,,23.01,2.35,5.33,30.690000000000005
+5472 Clacton on Sea,In Progress,BZL13293,,2025-06-27 16:59:48,24596/2,AS89981,BZL13293/42915,,,40x30 Poster OT,1,2025-06-30 14:21:08,Clacton on Sea,BUZ17449/125142,4.66,4.91,2.35,5.33,12.59
+5472 Clacton on Sea,In Progress,BZL13293,,2025-06-27 16:59:48,24596/4,AS85986,BZL13293/42909,,,40x30 Poster OT,1,2025-06-30 14:21:08,Clacton on Sea,BUZ17449/125136,4.66,4.91,2.35,5.33,12.59
+5543 Hanley,Completed,,B3261,2025-06-28 14:52:48,24604/1,,,BUZ12427/114467,B3261/1,Prize Draw Envelopes,4,2025-06-30 14:13:56,Hanley,,,0,9.4,18.6,28
+"""
+
+def _read_raw(csv_text: str) -> pd.DataFrame:
+    return pd.read_csv(io.StringIO("\n" + csv_text), header=None)
+
+
+def test_old_format_parsing():
+    raw = _read_raw(OLD_CSV)
+    df = parse_general_report(raw)
+    assert list(df.columns) == FINAL_COLUMNS
+    assert (df["Total"] > 0).any()
+    assert df["Print"].sum() == 0
+    assert df["Quantity"].dtype == int
+
+
+def test_new_format_parsing():
+    raw = _read_raw(NEW_CSV)
+    df = parse_general_report(raw)
+    assert list(df.columns) == FINAL_COLUMNS
+    assert (df["Total"] > 0).any()
+    assert df["Print"].sum() > 0
+    assert df["Quantity"].dtype == int


### PR DESCRIPTION
## Summary
- handle new and old ERA general reports with `parse_general_report`
- use unified cost columns when merging club data
- add tests for both general report formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899b3056fb0832a95b5f7f21f29e765